### PR TITLE
Plugin improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,17 @@ allow other apps to understand the structure of the build.
 const Chunks2JsonPlugin = require('chunks-2-json-webpack-plugin');
 const path = require('path');
 
+const publicPath = '/dist/';
+
 module.exports = {
   entry: './path/to/my/entry/file.js',
   output: {
     filename: 'my-first-webpack.bundle.js',
-    path: path.resolve(__dirname, 'dist')
+    path: path.resolve(__dirname, 'dist'),
+    publicPath
   },
   plugins: [
-    new Chunks2JsonPlugin({ outputDir: 'dist/', filename: 'my-app.json' })
+    new Chunks2JsonPlugin({ publicPath })
   ]
 };
 
@@ -43,25 +46,27 @@ module.exports = {
 ```JSON
 {
   "chunk-vendors": {
-    "js": "/js/chunk-vendors.fc40696c.js",
-    "jsMap": "/js/chunk-vendors.fc40696c.js.map"
+    "js": ["/js/chunk-vendors.fc40696c.js"],
+    "js.map": ["/js/chunk-vendors.fc40696c.js.map"]
   },
   "app": {
-    "css": "/css/app.eb829ccc.css",
-    "js": "/js/app.dd31cdcb.js",
-    "jsMap": "/js/app.dd31cdcb.js.map"
+    "css": ["/css/app.eb829ccc.css"],
+    "js": ["/js/app.dd31cdcb.js"],
+    "js.map": ["/js/app.dd31cdcb.js.map"]
   }
 }
 ```
 
 ## Options
 
-There are 2 input options available 
-
 | Option | Description |
 | ------------- |-------------|
-| outputDir | Folder in which to output the JSON file. If the folder does not exist, we'll try to create it |
-| filename | Name of the outputed JSON file |
+| excludeFile | `RegExp` or `function(filename, chunk definition object) => bool`. Exclude HMR chunks by default (file names ending with `.hot-update.js`). |
+| chunkGroupName | `function(filename, chunk definition object) => string`, generate chunk group name. Group by file extension (or `ext.map`) by default. |
+| outputDir | Output folder name. If the folder does not exist, we'll try to create it. Current working directory by default.  |
+| filename | Output file name. `build-manifest.json` by default. |
+| objectToString | `function(output structure) => string`, generate output file contents. `obj => JSON.stringify(obj)` by default. |
+| publicPath | String to prepend to all chunk file names. You probably should set it to the same value as `webpackConfig.output.publicPath`. Empty string by default. |
 
 ## Questions? 
 

--- a/index.js
+++ b/index.js
@@ -28,11 +28,11 @@ class Chunks2JsonWebpackPlugin {
                     this.result[chunk.name] = {};
                 }
                 chunk.files.forEach(filename => {
-                    const exclude = typeof options.excludeFile === 'function' ?
-                        options.excludeFile(filename, chunk) :
-                        options.excludeFile.test(filename);
+                    const exclude = typeof this.options.excludeFile === 'function' ?
+                        this.options.excludeFile(filename, chunk) :
+                        this.options.excludeFile.test(filename);
                     if (!exclude) {
-                        const ext = options.chunkGroupName(filename, chunk);
+                        const ext = this.options.chunkGroupName(filename, chunk);
                         if (!this.result[chunk.name][ext]) this.result[chunk.name][ext] = [];
                         this.result[chunk.name][ext].push(this.options.publicPath + filename);
                     }

--- a/index.js
+++ b/index.js
@@ -16,9 +16,11 @@ class Chunks2JsonWebpackPlugin {
                     this.result[chunk.name] = {};
                 }
                 chunk.files.forEach(filename => {
-                    const ext = /\.([a-z0-9]+(\.map)?)(\?.*)?$/i.exec(filename)[1];
-                    if (!this.result[chunk.name][ext]) this.result[chunk.name][ext] = [];
-                    this.result[chunk.name][ext].push((this.options.publicPath || '/') + filename);
+                    if (!filename.endsWith('.hot-update.js')) {
+                        const ext = /\.([a-z0-9]+(\.map)?)(\?.*)?$/i.exec(filename)[1];
+                        if (!this.result[chunk.name][ext]) this.result[chunk.name][ext] = [];
+                        this.result[chunk.name][ext].push((this.options.publicPath || '/') + filename);
+                    }
                 });
             });
             this.saveJson();

--- a/index.js
+++ b/index.js
@@ -10,20 +10,15 @@ class Chunks2JsonWebpackPlugin {
     }
     apply(compiler) {
         compiler.hooks.emit.tap(pluginName, compilation => {
-            compilation.chunks.forEach((chunk) => {
-                if (this.result[chunk.name] === undefined) {
+            this.result = {};
+            compilation.chunks.forEach(chunk => {
+                if (!this.result[chunk.name]) {
                     this.result[chunk.name] = {};
                 }
-                chunk.files.forEach((filename) => {
-                    if (filename.endsWith('css')) {
-                        this.result[chunk.name].css = `/${filename}`;
-                    } else if (filename.endsWith('js')) {
-                        this.result[chunk.name].js = `/${filename}`;
-                    } else if (filename.endsWith('js.map')) {
-                        this.result[chunk.name].jsMap = `/${filename}`;
-                    } else if (filename.endsWith('css.map')) {
-                        this.result[chunk.name].cssMap = `/${filename}`;
-                    }
+                chunk.files.forEach(filename => {
+                    const ext = /\.([a-z0-9]+(\.map)?)(\?.*)?$/i.exec(filename)[1];
+                    if (!this.result[chunk.name][ext]) this.result[chunk.name][ext] = [];
+                    this.result[chunk.name][ext].push((this.options.publicPath || '/') + filename);
                 });
             });
             this.saveJson();

--- a/index.js
+++ b/index.js
@@ -8,11 +8,11 @@ const defaultOptions = {
     excludeFile: /\.hot-update\.js$/,
     // group chunks by extension
     chunkGroupName: filename => /\.([a-z0-9]+(\.map)?)(\?.*)?$/.exec(filename)[1],
-    // generate contents to save to manifest file
-    objectToString: result => JSON.stringify(result),
     outputDir: process.cwd(),
     filename: 'build-manifest.json',
-    publicPath: '/'
+    // generate contents to save to manifest file
+    objectToString: result => JSON.stringify(result),
+    publicPath: ''
 };
 
 class Chunks2JsonWebpackPlugin {

--- a/index.js
+++ b/index.js
@@ -43,15 +43,18 @@ class Chunks2JsonWebpackPlugin {
     }
     saveJson() {
         const projectRoot = process.cwd();
-        let pathStep = projectRoot;
-        this.options.outputDir.replace(projectRoot, '').split('/').forEach((folder) => {
-            pathStep = path.join(pathStep, folder);
-            try {
-                fs.mkdirSync(pathStep);
-            } catch (e) {
-                // we don't care if it already exists, just continue...
-            }
-        });
+        // try to create outputDir folder if it is within project root
+        if (this.options.outputDir.startsWith(projectRoot) || !this.options.outputDir.startsWith('/')) {
+            let pathStep = projectRoot;
+            this.options.outputDir.replace(/^\.\//, '').replace(projectRoot, '').split('/').forEach((folder) => {
+                pathStep = path.join(pathStep, folder);
+                try {
+                    fs.mkdirSync(pathStep);
+                } catch (e) {
+                    // we don't care if it already exists, just continue...
+                }
+            });
+        }
         const file = path.resolve(this.options.outputDir, this.options.filename);
         const blob = this.options.objectToString(this.result);
         try {


### PR DESCRIPTION
Hi! I guess I made this plugin more community and production ready. There is a list of notable changes:

* More configuration options
* Files are grouped by their extensions (or `extension.map`) instead of hardcoded css/js strings
* File groups are now arrays since Webpack can emit multiple chunks per file type
* HMR update chunks are ignored by default
